### PR TITLE
feat: add share button with toast and deep-link modal support

### DIFF
--- a/src/components/AppModal.vue
+++ b/src/components/AppModal.vue
@@ -29,8 +29,8 @@ const shareToast = ref(false);
 
 const myModal = ref<HTMLDialogElement | null>(null)
 
-watch(() => app._openCount, async (newValue) => {
-  if (!app || !newValue) return;
+watch(() => abrir, async (newValue) => {
+  if (newValue && app) {
     bannerErrored.value = false;
     expandido.value = false;
     visible.value = false;
@@ -38,14 +38,24 @@ watch(() => app._openCount, async (newValue) => {
     visibleAlternatives.value = {}; 
     favicons.value = [];
 
-    await nextTick(); // desmonta com segurança
+    await nextTick();
 
-  // Set the app data and show modal
-  localApp.value = { ...app };
-  visible.value = true; // Set visible before showModal
-  
-  await nextTick(); // ensure DOM is ready
-  myModal.value?.showModal();
+    // Set the app data and show modal
+    localApp.value = { ...app };
+    visible.value = true;
+    
+    await nextTick();
+    myModal.value?.showModal();
+  } else if (!newValue) {
+    // Close modal when abrir becomes false
+    if (myModal.value?.open) {
+      myModal.value.close();
+    }
+  }
+});
+
+watch(() => app._openCount, async (newValue) => {
+  if (!app || !newValue) return;
 });
 
 function handleDialogClose() {
@@ -166,7 +176,14 @@ const { t } = useI18n();
     @close="handleDialogClose"
   >
   <div v-if="visible" class="modal-box w-full max-w-[880px] max-h-[calc(100vh-2rem)] overflow-y-auto rounded-xl relative bg-base-100 sm:px-6 sm:py-6 box-border">
-
+    <!-- Move toast inside the dialog -->
+    <div
+      v-if="shareToast"
+      class="absolute bottom-4 left-1/2 -translate-x-1/2 bg-base-200 text-base-content px-4 py-2 rounded shadow-lg z-50"
+      style="pointer-events: none;"
+    >
+      {{ t('appModal.linkCopied') || 'Link copied!' }}
+    </div>
 
     <!-- Botão de fechar -->
     <button
@@ -312,17 +329,6 @@ const { t } = useI18n();
     </div>
   </div>
 </dialog>
-<!-- Toast for "Link copied!" -->
-    <Teleport to="body">
-      <div
-        v-if="shareToast"
-        class="fixed bottom-8 left-1/2 -translate-x-1/2 bg-base-200 text-base-content px-4 py-2 rounded shadow-lg z-[9999]"
-        style="pointer-events: none;"
-      >
-        {{ t('appModal.linkCopied') || 'Link copied!' }}
-      </div>
-    </Teleport>
-
 
   </div>
 </template>

--- a/src/components/AppModal.vue
+++ b/src/components/AppModal.vue
@@ -3,6 +3,7 @@ import { ref, type Ref, defineProps, watch, onMounted, onBeforeUnmount, nextTick
 import { getAlternativeIcon } from '@/utils/global.ts';
 import { getProtocolInfo } from '@/utils/global.ts';
 import { getFaviconPath } from '@/utils/global.ts';
+import { getAppSlug } from '@/utils/global.ts';
 import type { App } from '@/types';
 import { useI18n } from 'vue-i18n';
 import { useRoute } from 'vue-router';
@@ -29,8 +30,7 @@ const shareToast = ref(false);
 const myModal = ref<HTMLDialogElement | null>(null)
 
 watch(() => app._openCount, async (newValue) => {
-  if (!app) return;
-  if (app) {
+  if (!app || !newValue) return;
     bannerErrored.value = false;
     expandido.value = false;
     visible.value = false;
@@ -40,16 +40,12 @@ watch(() => app._openCount, async (newValue) => {
 
     await nextTick(); // desmonta com segurança
 
-    localApp.value = { ...app };
-    myModal.value?.showModal();
-
-    await nextTick(); // garante render
-    visible.value = true;
-  } else {
-    visible.value = false;
-    myModal.value?.close();
-    emit('atualizarAbrir', false);
-  }
+  // Set the app data and show modal
+  localApp.value = { ...app };
+  visible.value = true; // Set visible before showModal
+  
+  await nextTick(); // ensure DOM is ready
+  myModal.value?.showModal();
 });
 
 function handleDialogClose() {
@@ -60,13 +56,6 @@ function handleDialogClose() {
   localApp.value = {}
 }
 
-function getAppSlug(app: Partial<App>) {
-  // Simple slugify: lowercase, remove spaces, remove special chars
-  return (app.name || '')
-    .toLowerCase()
-    .replace(/\s+/g, '')
-    .replace(/[^a-z0-9]/g, '');
-}
 
 async function shareApp() {
   const slug = getAppSlug(localApp.value);

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -58,6 +58,8 @@
     "close": "Close",
     "protocols": "Protocols and federation:",
     "alternatives": "Alternative to:",
+    "share": "Share",
+    "linkCopied": "Link copied!",
     "br": "BR"
   },
   "apps": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -58,6 +58,8 @@
     "close": "Cerrar",
     "protocols": "Protocolos y federación:",
     "alternatives": "Alternativa a:",
+    "share": "Compartir",
+    "linkCopied": "¡Enlace copiado!",
     "br": "BR"
   },
   "apps": {

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -58,6 +58,8 @@
     "close": "Fechar",
     "protocols": "Protocolos e federação:",
     "alternatives": "Alternativo para:",
+    "share": "Compartilhar",
+    "linkCopied": "Link copiado!",
     "br": "BR"
   },
   "apps": {

--- a/src/utils/global.ts
+++ b/src/utils/global.ts
@@ -1,6 +1,7 @@
 //globals.ts
 import { protocolIcons } from '@/data/protocols.ts';
 import { alternativeIcons } from '@/data/alternatives';
+import type { App } from '@/types';
 
 
 export const sliceText = (text: string, length: number) => {
@@ -51,4 +52,11 @@ export function getFaviconPath(url: string): string {
   } catch {
     return `${import.meta.env.BASE_URL}favicon.png`; // fallback
   }
+}
+
+export function getAppSlug(app: Partial<App>): string {
+  return (app.name || '')
+    .toLowerCase()
+    .replace(/\s+/g, '')
+    .replace(/[^a-z0-9]/g, '');
 }


### PR DESCRIPTION
## Description

Adds a "Share" button to the App Modal, allowing users to copy a shareable link for any app. When clicked, the link is copied to the clipboard and a toast notification confirms the action. The modal also auto-opens if the URL contains a matching `?app=slug` query parameter, supporting deep linking and sharing. All UI text is fully internationalized.

## Changes made

- [x] Feature added: Share button in App

Closes #54 

## How to test it
1. Start the app and open any app modal.
2. Click the "Share" button; a toast should appear confirming the link was copied.
3. Paste the clipboard contents to verify the link includes ?app=slug.
4. Open the app with a URL like /?app=nextcloud (replace with a valid slug); the modal should auto-open.
5. Change the language and verify the button and toast are translated.

## Checklist

- [x] My code follows the style of this project
- [x] I’ve tested it or verified it works as expected
- [x] I’ve added comments or documentation where needed

---

### Contributor Statement

By submitting this pull request, I confirm that:

- I am voluntarily contributing this code under the project's license  
- I have the legal right to do so  
- I understand this contribution may be modified or redistributed under that license
