### PR TITLE
fixed the Modal link missing /guia path

### DIFF
--- a/src/components/AppModal.vue
+++ b/src/components/AppModal.vue
@@ -70,7 +70,7 @@ function handleDialogClose() {
 async function shareApp() {
   const slug = getAppSlug(localApp.value);
   // Build the shareable URL with ?app=slug
-  const basePath = window.location.origin + route.fullPath.split('?')[0];
+  const basePath = window.location.origin + window.location.pathname;
   const url = `${basePath}?app=${slug}`;
   await navigator.clipboard.writeText(url);
   shareToast.value = true;


### PR DESCRIPTION
## Description
Fixed the bug for the modal link missing. Used the optimal and simpler version, alternate is to use useRouter for path definition. Would suggest to stick with this

#123 covered here

### Contributor Statement

By submitting this pull request, I confirm that:

- I am voluntarily contributing this code under the project's license  
- I have the legal right to do so  
- I understand this contribution may be modified or redistributed under that license
