### PR TITLE
added self hosting difficulty for each modal

### DIFF
--- a/src/components/AppModal.vue
+++ b/src/components/AppModal.vue
@@ -309,7 +309,24 @@ const { t } = useI18n();
 
           </div>
         </div>
-
+        <div v-if="localApp.selfHostingLevel" class="mt-4 flex items-center gap-2">
+          <span class="font-semibold" :title="t('appModal.selfHostingTooltip') || 'Self-hosting difficulty'">
+            {{ t('appModal.selfHostingLabel') || 'Self-hosting difficulty:' }}
+          </span>
+          <span
+            :class="[
+              'inline-flex items-center gap-1 text-lg',
+              localApp.selfHostingLevel === 1 ? 'text-green-500' :
+              localApp.selfHostingLevel === 2 ? 'text-yellow-500' :
+              'text-red-500'
+            ]"
+          >
+            <template v-for="n in 3">
+              <span v-if="n <= localApp.selfHostingLevel">⭐</span>
+              <span v-else>◽️</span>
+            </template>
+          </span>
+        </div>
         <div v-if="localApp.alternatives?.length" class="mt-4">
           <h4 class="sm:text-lg font-semibold mb-2">{{ t('appModal.alternatives') }}</h4>
           <div class="flex flex-wrap gap-2">

--- a/src/data/apps.ts
+++ b/src/data/apps.ts
@@ -4,6 +4,7 @@ import i18n from '@/i18n';
 export const apps: App[] = [
   {
     name: 'PeerTube',
+    selfHostingLevel: 2,
     description: i18n.global.t('apps.peertube.description'),
     longDescription: i18n.global.t('apps.peertube.longDescription'),
     features: [
@@ -36,6 +37,7 @@ export const apps: App[] = [
   },
   {
     name: 'Mastodon',
+    selfHostingLevel: 2,
     description: i18n.global.t('apps.mastodon.description'),
     longDescription: i18n.global.t('apps.mastodon.longDescription'),
     features: [
@@ -71,6 +73,7 @@ export const apps: App[] = [
   },
   {
     name: 'Nextcloud',
+    selfHostingLevel: 1,
     description: i18n.global.t('apps.nextcloud.description'),
     longDescription: i18n.global.t('apps.nextcloud.longDescription'),
     features: [
@@ -103,6 +106,7 @@ export const apps: App[] = [
   },
   {
     name: 'Vaultwarden',
+    selfHostingLevel: 1,
     description: i18n.global.t('apps.vaultwarden.description'),
     longDescription: i18n.global.t('apps.vaultwarden.longDescription'),
     features: [
@@ -133,6 +137,7 @@ export const apps: App[] = [
   },
   {
     name: 'Passbolt',
+    selfHostingLevel: 2,
     description: i18n.global.t('apps.passbolt.description'),
     longDescription: i18n.global.t('apps.passbolt.longDescription'),
     features: [
@@ -165,6 +170,7 @@ export const apps: App[] = [
 
   {
     name: 'Element',
+    selfHostingLevel: 2,
     description: i18n.global.t('apps.element.description'),
     longDescription: i18n.global.t('apps.element.longDescription'),
     features: [
@@ -194,6 +200,7 @@ export const apps: App[] = [
   },
   {
     name: 'Lemmy',
+    selfHostingLevel: 2,
     description: i18n.global.t('apps.lemmy.description'),
     longDescription: i18n.global.t('apps.lemmy.longDescription'),
     features: [
@@ -224,6 +231,7 @@ export const apps: App[] = [
 
   {
     name: 'Jitsi Meet',
+    selfHostingLevel: 2,
     description: i18n.global.t('apps.jitsimeet.description'),
     longDescription: i18n.global.t('apps.jitsimeet.longDescription'),
     features: [
@@ -257,6 +265,7 @@ export const apps: App[] = [
 
   {
     name: 'BookStack',
+    selfHostingLevel: 1,
     description: i18n.global.t('apps.bookstack.description'),
     longDescription: i18n.global.t('apps.bookstack.longDescription'),
     features: [
@@ -288,6 +297,7 @@ export const apps: App[] = [
   },
   {
     name: 'RSSHub',
+    selfHostingLevel: 1,
     description: i18n.global.t('apps.rsshub.description'),
     longDescription: i18n.global.t('apps.rsshub.longDescription'),
     features: [
@@ -314,6 +324,7 @@ export const apps: App[] = [
   },
   {
     name: 'Discourse',
+    selfHostingLevel: 3,
     description: i18n.global.t('apps.discourse.description'),
     longDescription: i18n.global.t('apps.discourse.longDescription'),
     features: [
@@ -346,6 +357,7 @@ export const apps: App[] = [
 
   {
     name: 'Pixelfed',
+    selfHostingLevel: 2,
     description: i18n.global.t('apps.pixelfed.description'),
     longDescription: i18n.global.t('apps.pixelfed.longDescription'),
     features: [
@@ -376,6 +388,7 @@ export const apps: App[] = [
 
   {
     name: 'Signal',
+    selfHostingLevel: 3,
     description: i18n.global.t('apps.signal.description'),
     longDescription: i18n.global.t('apps.signal.longDescription'),
     features: [
@@ -405,6 +418,7 @@ export const apps: App[] = [
   },
   {
     name: 'Stirling-PDF',
+    selfHostingLevel: 1,
     description: i18n.global.t('apps.stirling-pdf.description'),
     longDescription: i18n.global.t('apps.stirling-pdf.longDescription'),
     features: [
@@ -435,6 +449,7 @@ export const apps: App[] = [
   },
   {
     name: 'ActivityPub',
+    selfHostingLevel: 3,
     description: i18n.global.t('apps.activitypub.description'),
     longDescription: i18n.global.t('apps.activitypub.longDescription'),
     features: [
@@ -470,6 +485,7 @@ export const apps: App[] = [
 
   {
     name: 'Matrix',
+    selfHostingLevel: 2,
     description: i18n.global.t('apps.matrix.description'),
     longDescription: i18n.global.t('apps.matrix.longDescription'),
     features: [
@@ -495,6 +511,7 @@ export const apps: App[] = [
   },
   {
     name: 'XMPP',
+    selfHostingLevel: 2,
     description: i18n.global.t('apps.xmpp.description'),
     longDescription: i18n.global.t('apps.xmpp.longDescription'),
     features: [
@@ -524,6 +541,7 @@ export const apps: App[] = [
   },
   {
     name: 'Email',
+    selfHostingLevel: 3,
     description: i18n.global.t('apps.email.description'),
     longDescription: i18n.global.t('apps.email.longDescription'),
     features: [
@@ -555,6 +573,7 @@ export const apps: App[] = [
   },
   {
     name: 'Ghost',
+    selfHostingLevel: 1,
     description: i18n.global.t('apps.ghost.description'),
     longDescription: i18n.global.t('apps.ghost.longDescription'),
     features: [
@@ -582,6 +601,7 @@ export const apps: App[] = [
 
   {
     name: 'Misskey',
+    selfHostingLevel: 2,
     description: i18n.global.t('apps.misskey.description'),
     longDescription: i18n.global.t('apps.misskey.longDescription'),
     features: [
@@ -615,6 +635,7 @@ export const apps: App[] = [
   },
   {
     name: 'Rocket.Chat',
+    selfHostingLevel: 1,
     description: i18n.global.t('apps.rocketchat.description'),
     longDescription: i18n.global.t('apps.rocketchat.longDescription'),
     features: [
@@ -646,6 +667,7 @@ export const apps: App[] = [
   },
   {
     name: 'Plane',
+    selfHostingLevel: 1,
     description: i18n.global.t('apps.plane.description'),
     longDescription: i18n.global.t('apps.plane.longDescription'),
     features: [
@@ -671,6 +693,7 @@ export const apps: App[] = [
   },
   {
     name: 'IPFS',
+    selfHostingLevel: 2,
     description: i18n.global.t('apps.ipfs.description'),
     longDescription: i18n.global.t('apps.ipfs.longDescription'),
     features: [
@@ -696,6 +719,7 @@ export const apps: App[] = [
   },
   {
     name: 'Bitwarden',
+    selfHostingLevel: 2,
     description: i18n.global.t('apps.bitwarden.description'),
     longDescription: i18n.global.t('apps.bitwarden.longDescription'),
     features: [
@@ -728,6 +752,7 @@ export const apps: App[] = [
 
   {
     name: 'Diaspora*',
+    selfHostingLevel: 2,
     description: i18n.global.t('apps.diaspora.description'),
     longDescription: i18n.global.t('apps.diaspora.longDescription'),
     features: [
@@ -760,6 +785,7 @@ export const apps: App[] = [
   },
   {
     name: 'Jellyfin',
+    selfHostingLevel: 1,
     description: i18n.global.t('apps.jellyfin.description'),
     longDescription: i18n.global.t('apps.jellyfin.longDescription'),
     features: [
@@ -791,6 +817,7 @@ export const apps: App[] = [
   },
   {
     name: 'Zulip',
+    selfHostingLevel: 2,
     description: i18n.global.t('apps.zulip.description'),
     longDescription: i18n.global.t('apps.zulip.longDescription'),
     features: [
@@ -819,6 +846,7 @@ export const apps: App[] = [
   },
   {
     name: 'osTicket',
+    selfHostingLevel: 1,
     description: i18n.global.t('apps.osticket.description'),
     longDescription: i18n.global.t('apps.osticket.longDescription'),
     features: [
@@ -850,6 +878,7 @@ export const apps: App[] = [
   },
   {
     name: 'Friendica',
+    selfHostingLevel: 2,
     description: i18n.global.t('apps.friendica.description'),
     longDescription: i18n.global.t('apps.friendica.longDescription'),
     features: [
@@ -883,6 +912,7 @@ export const apps: App[] = [
 
   {
     name: 'Pleroma',
+    selfHostingLevel: 2,
     description: i18n.global.t('apps.pleroma.description'),
     longDescription: i18n.global.t('apps.pleroma.longDescription'),
     features: [
@@ -915,6 +945,7 @@ export const apps: App[] = [
   },
   {
     name: 'Hubzilla',
+    selfHostingLevel: 3,
     description: i18n.global.t('apps.hubzilla.description'),
     longDescription: i18n.global.t('apps.hubzilla.longDescription'),
     features: [
@@ -944,6 +975,7 @@ export const apps: App[] = [
   },
   {
     name: 'Mattermost',
+    selfHostingLevel: 2,
     description: i18n.global.t('apps.mattermost.description'),
     longDescription: i18n.global.t('apps.mattermost.longDescription'),
     features: [
@@ -975,6 +1007,7 @@ export const apps: App[] = [
   },
   {
     name: 'BigBlueButton',
+    selfHostingLevel: 3,
     description: i18n.global.t('apps.bigbluebutton.description'),
     longDescription: i18n.global.t('apps.bigbluebutton.longDescription'),
     features: [
@@ -1007,6 +1040,7 @@ export const apps: App[] = [
   },
   {
     name: 'GitLab',
+    selfHostingLevel: 3,
     description: i18n.global.t('apps.gitlab.description'),
     longDescription: i18n.global.t('apps.gitlab.longDescription'),
     features: [
@@ -1033,6 +1067,7 @@ export const apps: App[] = [
   },
   {
     name: 'Gitea',
+    selfHostingLevel: 1,
     description: i18n.global.t('apps.gitea.description'),
     longDescription: i18n.global.t('apps.gitea.longDescription'),
     features: [
@@ -1062,6 +1097,7 @@ export const apps: App[] = [
   },
   {
     name: 'OpenProject',
+    selfHostingLevel: 2,
     description: i18n.global.t('apps.openproject.description'),
     longDescription: i18n.global.t('apps.openproject.longDescription'),
     features: [
@@ -1093,6 +1129,7 @@ export const apps: App[] = [
   },
   {
     name: 'Uptime Kuma',
+    selfHostingLevel: 1,
     description: i18n.global.t('apps.uptimekuma.description'),
     longDescription: i18n.global.t('apps.uptimekuma.longDescription'),
     features: [
@@ -1123,6 +1160,7 @@ export const apps: App[] = [
   },
   {
     name: 'Plex',
+    selfHostingLevel: 2,
     description: i18n.global.t('apps.plex.description'),
     longDescription: i18n.global.t('apps.plex.longDescription'),
     features: [
@@ -1151,6 +1189,7 @@ export const apps: App[] = [
   },
   {
     name: 'LanguageTool',
+    selfHostingLevel: 1,
     description: i18n.global.t('apps.languagetool.description'),
     longDescription: i18n.global.t('apps.languagetool.longDescription'),
     features: [
@@ -1182,6 +1221,7 @@ export const apps: App[] = [
   },
   {
     name: 'Owncast',
+    selfHostingLevel: 1,
     description: i18n.global.t('apps.owncast.description'),
     longDescription: i18n.global.t('apps.owncast.longDescription'),
     features: [
@@ -1210,6 +1250,7 @@ export const apps: App[] = [
   },
   {
     name: 'AzuraCast',
+    selfHostingLevel: 2,
     description: i18n.global.t('apps.azuracast.description'),
     longDescription: i18n.global.t('apps.azuracast.longDescription'),
     features: [
@@ -1238,6 +1279,7 @@ export const apps: App[] = [
   },
   {
     name: 'Keycloak',
+    selfHostingLevel: 2,
     description: i18n.global.t('apps.keycloak.description'),
     longDescription: i18n.global.t('apps.keycloak.longDescription'),
     features: [
@@ -1270,6 +1312,7 @@ export const apps: App[] = [
   },
   {
     name: 'WordPress',
+    selfHostingLevel: 1,
     description: i18n.global.t('apps.wordpress.description'),
     longDescription: i18n.global.t('apps.wordpress.longDescription'),
     features: [
@@ -1301,6 +1344,7 @@ export const apps: App[] = [
   },
   {
     name: 'AT Protocol',
+    selfHostingLevel: 3,
     description: i18n.global.t('apps.atprotocol.description'),
     longDescription: i18n.global.t('apps.atprotocol.longDescription'),
     features: [
@@ -1330,6 +1374,7 @@ export const apps: App[] = [
 
   {
     name: 'Bluesky',
+    selfHostingLevel: 3,
     description: i18n.global.t('apps.bluesky.description'),
     longDescription: i18n.global.t('apps.bluesky.longDescription'),
     features: [
@@ -1356,6 +1401,7 @@ export const apps: App[] = [
   },
   {
     name: 'RSS',
+    selfHostingLevel: 1,
     description: i18n.global.t('apps.rss.description'),
     longDescription: i18n.global.t('apps.rss.longDescription'),
     features: [
@@ -1387,6 +1433,7 @@ export const apps: App[] = [
   },
   {
     name: 'Atom',
+    selfHostingLevel: 1,
     description: i18n.global.t('apps.atom.description'),
     longDescription: i18n.global.t('apps.atom.longDescription'),
     features: [
@@ -1415,6 +1462,7 @@ export const apps: App[] = [
   },
   {
     name: 'BitTorrent',
+    selfHostingLevel: 1,
     description: i18n.global.t('apps.bittorrent.description'),
     longDescription: i18n.global.t('apps.bittorrent.longDescription'),
     features: [
@@ -1446,6 +1494,7 @@ export const apps: App[] = [
   },
   {
     name: 'Nostr',
+    selfHostingLevel: 2,
     description: i18n.global.t('apps.nostr.description'),
     longDescription: i18n.global.t('apps.nostr.longDescription'),
     features: [
@@ -1477,6 +1526,7 @@ export const apps: App[] = [
   },
   {
     name: 'Tor',
+    selfHostingLevel: 2,
     description: i18n.global.t('apps.tor.description'),
     longDescription: i18n.global.t('apps.tor.longDescription'),
     features: [
@@ -1502,6 +1552,7 @@ export const apps: App[] = [
   },
   {
     name: 'Grafana',
+    selfHostingLevel: 1,
     description: i18n.global.t('apps.grafana.description'),
     longDescription: i18n.global.t('apps.grafana.longDescription'),
     features: [
@@ -1530,6 +1581,7 @@ export const apps: App[] = [
   },
   {
     name: 'Prometheus',
+    selfHostingLevel: 2,
     description: i18n.global.t('apps.prometheus.description'),
     longDescription: i18n.global.t('apps.prometheus.longDescription'),
     features: [
@@ -1561,6 +1613,7 @@ export const apps: App[] = [
   },
   {
     name: 'Funkwhale',
+    selfHostingLevel: 2,
     description: i18n.global.t('apps.funkwhale.description'),
     longDescription: i18n.global.t('apps.funkwhale.longDescription'),
     features: [
@@ -1594,6 +1647,7 @@ export const apps: App[] = [
 
   {
     name: 'IRC',
+    selfHostingLevel: 1,
     description: i18n.global.t('apps.irc.description'),
     longDescription: i18n.global.t('apps.irc.longDescription'),
     features: [
@@ -1625,6 +1679,7 @@ export const apps: App[] = [
   },
   {
     name: 'The Lounge',
+    selfHostingLevel: 1,
     description: i18n.global.t('apps.thelounge.description'),
     longDescription: i18n.global.t('apps.thelounge.longDescription'),
     features: [
@@ -1657,6 +1712,7 @@ export const apps: App[] = [
   },
   {
     name: 'La Suite',
+    selfHostingLevel: 2,
     description: i18n.global.t('apps.lasuite.description'),
     longDescription: i18n.global.t('apps.lasuite.longDescription'),
     features: [

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -60,7 +60,9 @@
     "alternatives": "Alternative to:",
     "share": "Share",
     "linkCopied": "Link copied!",
-    "br": "BR"
+    "br": "BR",
+    "selfHostingLabel": "Self-hosting difficulty",
+    "selfHostingTooltip": "How hard it is to self-host this app (1=Easy, 3=Advanced)"
   },
   "surpriseMe": {
     "button": "Surprise me!"

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -60,7 +60,9 @@
     "alternatives": "Alternativa a:",
     "share": "Compartir",
     "linkCopied": "¡Enlace copiado!",
-    "br": "BR"
+    "br": "BR",
+    "selfHostingLabel": "Dificultad de auto-hospedaje",
+    "selfHostingTooltip": "Qué tan difícil es auto-hospedar esta app (1=Fácil, 3=Avanzado)"
   },
   "surpriseMe": {
     "button": "¡Sorpréndeme!"

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -60,7 +60,9 @@
     "alternatives": "Alternativo para:",
     "share": "Compartilhar",
     "linkCopied": "Link copiado!",
-    "br": "BR"
+    "br": "BR",
+    "selfHostingLabel": "Dificuldade de auto-hospedagem",
+    "selfHostingTooltip": "Quão difícil é auto-hospedar este app (1=Fácil, 3=Avançado)"
   },
   "surpriseMe": {
     "button": "Me surpreenda!"

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,7 +19,7 @@ export interface App {
     src: string;
     alt: string;
   };
-
+  selfHostingLevel?: 1 | 2 | 3;
 }
 
 export interface FilterItem {


### PR DESCRIPTION
## Description

Adds the `selfHostingLevel` property to all app objects in `apps.ts` and updates the `App` interface in `types.ts` to ensure type safety and consistency.

## Changes made

- [x] Feature added: `selfHostingLevel` field for all apps
- [x] Type definition updated in `App` interface
- [ ] Bugfix
- [ ] Refactoring
- [ ] Docs update
- [ ] Other (please describe):

## Related issue

Closes #72 

## How to test it

- Open the app modal or card and verify that the self-hosting difficulty is displayed for each app.
- Check that there are no TypeScript errors related to the new field.

## Checklist

- [x] My code follows the style of this project
- [x] I’ve tested it or verified it works as expected
- [x] I’ve added comments or documentation where needed

---

### Contributor Statement

By submitting this pull request, I confirm that:

- I am voluntarily contributing this code under the project's license  
- I have the legal right to do so  
- I understand this contribution may be modified or redistributed under that license